### PR TITLE
Generate TreeAdapter Javadoc in the correct place

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	
 	<groupId>com.siliconage</groupId>
 	<artifactId>siliconage</artifactId>
-	<version>3.2.0</version>
+	<version>3.2.1</version>
 	
 	<properties>
 		<maven.compiler.source>21</maven.compiler.source>

--- a/src/main/java/com/opal/creator/ClassGenerator.java
+++ b/src/main/java/com/opal/creator/ClassGenerator.java
@@ -1782,11 +1782,10 @@ public class ClassGenerator {
 				String lclFQICN = lclMC.getFullyQualifiedInterfaceClassName();
 				String lclTABase = TreeAdapter.class.getName() + "<" + lclFQICN + ">";
 				
+				lclBW.println("\t/** This is a singleton class of which only one instance should ever exist.  Clients of this class");
+				lclBW.println("\tshould not create their own instances using a constructor, but should instead invoke the static");
+				lclBW.println("\tmethod {@code getInstance()} to access the singleton instance. */");
 				lclBW.println("\tpublic static class " + lclTA + " extends " + lclTABase + " {");
-				lclBW.println("\t\t/** This is a singleton class of which only one instance should ever exist.  Clients of this class");
-				lclBW.println("\t\tshould not create their own instances using a constructor, but should instead invoke the static");
-				lclBW.println("\t\tmethod {@code getInstance()} to access the singleton instance. */");
-				lclBW.println();
 				lclBW.println("\t\t/** A static reference to the only instance of this class, which is constructed on class load. */");
 				lclBW.println();
 				lclBW.println("\t\tprivate static final " + lclTA + " ourInstance = new " + lclTA + "();");


### PR DESCRIPTION
Right now it's within the class rather than above (and thus attached to) the class. This causes warnings in Java 25 (and is just wrong).