### PR TITLE
Upgrade dependencies and bump version to 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,14 @@
 	
 	<groupId>com.siliconage</groupId>
 	<artifactId>siliconage</artifactId>
-	<version>3.3.2</version>
+	<version>3.4.0</version>
 	
 	<properties>
 		<maven.compiler.source>25</maven.compiler.source>
 		<maven.compiler.target>25</maven.compiler.target>
 		<maven.compiler.release>25</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 	</properties>
 	
 	<dependencies>
@@ -28,38 +30,45 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-collections4</artifactId>
-			<version>4.0</version>
+			<version>4.4</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.20.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.17.1</version>
+			<version>1.22.0</version>
 		</dependency>
 		
 		<dependency>
-			<groupId>commons-text</groupId>
+			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
 			<version>1.15.0</version>
+			<scope>compile</scope>
 		</dependency>
 		
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.1</version>
+			<version>2.14.0</version>
 		</dependency>
 		
-		<!-- The comment on this one is surely no longer true since it now contains the Opal XMLCreator code. -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.16</version>
-		</dependency><!-- No logging implementation is provided because the siliconage library contains no code that can meaningfully be executed on its own. -->
+			<version>2.0.18</version>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j2-impl</artifactId>
+			<version>2.26.1</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Mostly, this is bumping the version because of the changes in #41. While I was at it, I also performed minor dependency version upgrades.